### PR TITLE
Update gradle plugin id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ subprojects {
     {
         p.evaluationDependsOn(BuildUtils.getApiProjectPath(p.gradle))
         apply plugin: 'java'
-        apply plugin: 'org.labkey.fileModule' // This repository should only contain file-based modules
+        apply plugin: 'org.labkey.build.fileModule' // This repository should only contain file-based modules
     }
 }
 


### PR DESCRIPTION
#### Rationale
The old ids for our Gradle plugins have been removed in `24.2`. The new id (`org.labkey.build.fileModule`) has been available since 21.1 so this should be sufficiently backward compatible.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/668
* https://github.com/LabKey/gradlePlugin/pull/190
* https://github.com/LabKey/gradlePlugin/pull/192

#### Changes
* Gradle plugins version update