### PR TITLE
Remove unsupported Version property

### DIFF
--- a/AssayPortal/module.properties
+++ b/AssayPortal/module.properties
@@ -1,5 +1,4 @@
 Name: AssayPortal
-Version: 19.20
 ModuleClass: org.labkey.api.module.SimpleModule
 Label: AssayPortal R scripts and queries
 Description: This module contains the custom queries and R scripts used in the\


### PR DESCRIPTION
Latest gradlePlugins version will throw if it sees an unsupported property like this

https://github.com/LabKey/gradlePlugin/pull/229